### PR TITLE
Disable monitor Vsync to allow Oculus Rift frame rates (90Hhz)

### DIFF
--- a/OculusRiftSample/Game.cs
+++ b/OculusRiftSample/Game.cs
@@ -23,6 +23,7 @@ namespace OculusRiftSample
 			gdm = new GraphicsDeviceManager(this);
 			gdm.PreferredBackBufferWidth = 800;
 			gdm.PreferredBackBufferHeight = 600;
+            gdm.SynchronizeWithVerticalRetrace = false;
             IsFixedTimeStep = false;
         }
 


### PR DESCRIPTION
Currently the gameloop is limited ftom the monitor frame rate (typically =60fps)