### PR TITLE
Use HiDef Profile

### DIFF
--- a/OculusRiftSample/Game.cs
+++ b/OculusRiftSample/Game.cs
@@ -23,6 +23,7 @@ namespace OculusRiftSample
 			gdm = new GraphicsDeviceManager(this);
 			gdm.PreferredBackBufferWidth = 800;
 			gdm.PreferredBackBufferHeight = 600;
+            gdm.GraphicsProfile = GraphicsProfile.HiDef;
             gdm.SynchronizeWithVerticalRetrace = false;
             IsFixedTimeStep = false;
         }


### PR DESCRIPTION
Newer versions of MonoGame always begin with profile set to Reach, which cause an error -3000 in Riff.Init(...)  
Tested with MG 3.6 and develop 3.7.0.0741 (Aug 2017)